### PR TITLE
Fixed a bug within the DecodeIntent samples project.

### DIFF
--- a/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentService.java
+++ b/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentService.java
@@ -33,7 +33,7 @@ public class IntentService extends Service {
 
 		String type = intent.getStringExtra(IntentWedgeSample.EXTRA_TYPE);
 		// Retrieve result data.
-		String data = intent.getStringExtra(IntentWedgeSample.EXTRA_DATA);
+		String data = intent.getStringExtra(IntentWedgeSample.EXTRA_DATA_STRING);
 
 		NotificationManager notificationManager =
 				(NotificationManager) getSystemService(NOTIFICATION_SERVICE);

--- a/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentStartActivity.java
+++ b/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentStartActivity.java
@@ -38,8 +38,8 @@ public class IntentStartActivity extends Activity {
 
 		// Which Barcode type?
 		String type = intent.getStringExtra(IntentWedgeSample.EXTRA_TYPE);
-		// What is the result?
-		String data = intent.getStringExtra(IntentWedgeSample.EXTRA_DATA);
+		// Get the Barcode value
+		String data = intent.getStringExtra(IntentWedgeSample.EXTRA_DATA_STRING);
 
 		textMsg = (TextView) findViewById(R.id.textResult);
 		textMsg.append("Action: " + action + "\n" 

--- a/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentWedgeSample.java
+++ b/DecodeIntent/app/src/main/java/com/datalogic/examples/decodeintent/IntentWedgeSample.java
@@ -34,6 +34,7 @@ public class IntentWedgeSample extends Activity {
 	// Default Extra contents added to the intent containing results.
 	public static final String EXTRA_DATA = IntentWedge.EXTRA_BARCODE_DATA;
 	public static final String EXTRA_TYPE = IntentWedge.EXTRA_BARCODE_TYPE;
+	public static final String EXTRA_DATA_STRING = IntentWedge.EXTRA_BARCODE_STRING;
 
 	// Action and Category defined in AndroidManifest.xml, associated to a dedicated activity.
 	private static final String ACTION = "com.datalogic.examples.STARTINTENT" ;
@@ -124,7 +125,7 @@ public class IntentWedgeSample extends Activity {
 			if (action.equals(ACTION_BROADCAST_RECEIVER)) {
 
 				// Read content of result intent.
-				String barcode = wedgeIntent.getStringExtra(EXTRA_DATA);
+				String barcode = wedgeIntent.getStringExtra(EXTRA_DATA_STRING);
 
 				showMessage("Received intent broadcast:" + barcode);
 				Log.d(LOGTAG, "Decoding Broadcast Received");

--- a/DeviceSampleAPI/app/build.gradle
+++ b/DeviceSampleAPI/app/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         applicationId "com.datalogic.examples.devicesampleapi"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }

--- a/DeviceSampleAPI/app/src/main/java/com/datalogic/examples/devicesampleapi/InfoActivity.java
+++ b/DeviceSampleAPI/app/src/main/java/com/datalogic/examples/devicesampleapi/InfoActivity.java
@@ -75,6 +75,7 @@ public class InfoActivity extends Activity {
 		);
 	}
 
+
 	public String getSDKVersion() {
 		return SYSTEM.SDK_VERSION;
 	}

--- a/DeviceSampleAPI/app/src/main/java/com/datalogic/examples/devicesampleapi/ResetActivity.java
+++ b/DeviceSampleAPI/app/src/main/java/com/datalogic/examples/devicesampleapi/ResetActivity.java
@@ -42,8 +42,7 @@ public class ResetActivity extends Activity {
 		// Set listArray and bootTypes
 		setArray();
 
-		ArrayAdapter<Object> adapter = new ArrayAdapter<Object>(this,
-				android.R.layout.simple_list_item_1, listArray);
+		ArrayAdapter<Object> adapter = new ArrayAdapter<Object>(this, android.R.layout.simple_list_item_1, listArray);
 		listReset = (ListView) findViewById(R.id.listReset);
 		listReset.setAdapter(adapter);
 		listReset.setOnItemClickListener(new ResetAdapter());


### PR DESCRIPTION
IntentService and IntentStartActivity were trying to access the scanned
barcode embedded within the broadcasted intent using:
intent.getStringExtra(IntentWedgeSample.EXTRA_DATA.  This was returning
a null object for IntentStartActivity and an exception for IntentService because the bardcode stored in the intent's data was an array of barcode characters.  The solution to fix this problem was to use IntentWedgeSample.EXTRA_DATA_STRING which retrieved the barcode value as a string.